### PR TITLE
Remove abstractclassmethod reference from ABC

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 
   # Adds a standard feel to import segments
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.0.1
+    rev: v3.1.0
     hooks:
       - id: reorder-python-imports
         args: [--py3-plus]
@@ -45,6 +45,6 @@ repos:
 
   # Type enforcement for Python
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.950
     hooks:
       - id: mypy

--- a/src/picartoapi/model/base_model.py
+++ b/src/picartoapi/model/base_model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from abc import ABC
-from abc import abstractclassmethod
+from abc import abstractmethod
 from typing import Any
 
 
@@ -21,6 +21,7 @@ class BaseModel(ABC):
         """Returns objects as serialized dictionary (JSON)"""
         return json.loads(self.__repr__())
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def build_from(cls, model_data: dict[str, Any]) -> BaseModel:
         raise NotImplementedError


### PR DESCRIPTION
`abstractclassmethod` was deprecated in 3.3. Chaining `classmethod` and `abstractmethod` now accomplish the desired result.